### PR TITLE
chg: add support for PVC selector

### DIFF
--- a/charts/mealie/templates/pvc.yaml
+++ b/charts/mealie/templates/pvc.yaml
@@ -18,4 +18,10 @@ spec:
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}
+  {{- if .Values.persistence.selector }}
+  {{- with .Values.persistence.selector }}
+  selector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
This PR allows to set a PVC selector, which comes handy especially with local-storage driver.