### PR TITLE
Feature: Add support for existing PVCs in persistence configuration

### DIFF
--- a/charts/paperless-ngx/Chart.yaml
+++ b/charts/paperless-ngx/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: paperless-ngx
 description: Paperless-ngx helm chart for Kubernetes
 type: application
-version: 0.0.2
+version: 0.0.3
 appVersion: "latest"
 maintainers:
   - name: Richard Tomik

--- a/charts/paperless-ngx/readme.md
+++ b/charts/paperless-ngx/readme.md
@@ -128,12 +128,16 @@ The following table lists the configurable parameters and their default values.
 |----------------------------------------|--------------------------------------------------------------------|---------------------|
 | `persistence.data.enabled`            | Enable persistence for data directory                             | `true`              |
 | `persistence.data.size`               | Size of data PVC                                                  | `1Gi`               |
+| `persistence.data.existingClaim`      | Name of existing PVC to use for data directory                    | `""`                |
 | `persistence.media.enabled`           | Enable persistence for media directory                            | `true`              |
 | `persistence.media.size`              | Size of media PVC                                                 | `10Gi`              |
+| `persistence.media.existingClaim`     | Name of existing PVC to use for media directory                   | `""`                |
 | `persistence.consume.enabled`         | Enable persistence for consume directory                          | `true`              |
 | `persistence.consume.size`            | Size of consume PVC                                               | `5Gi`               |
+| `persistence.consume.existingClaim`   | Name of existing PVC to use for consume directory                 | `""`                |
 | `persistence.export.enabled`          | Enable persistence for export directory                           | `true`              |
 | `persistence.export.size`             | Size of export PVC                                                | `1Gi`               |
+| `persistence.export.existingClaim`    | Name of existing PVC to use for export directory                  | `""`                |
 
 ### Service Parameters
 

--- a/charts/paperless-ngx/templates/deployment.yaml
+++ b/charts/paperless-ngx/templates/deployment.yaml
@@ -324,7 +324,7 @@ spec:
         {{- if .Values.persistence.data.enabled }}
         - name: data
           persistentVolumeClaim:
-            claimName: {{ include "paperless-ngx.fullname" . }}-data
+            claimName: {{ .Values.persistence.data.existingClaim | default (printf "%s-data" (include "paperless-ngx.fullname" .)) }}
         {{- else }}
         - name: data
           emptyDir: {}
@@ -332,7 +332,7 @@ spec:
         {{- if .Values.persistence.media.enabled }}
         - name: media
           persistentVolumeClaim:
-            claimName: {{ include "paperless-ngx.fullname" . }}-media
+            claimName: {{ .Values.persistence.media.existingClaim | default (printf "%s-media" (include "paperless-ngx.fullname" .)) }}
         {{- else }}
         - name: media
           emptyDir: {}
@@ -340,7 +340,7 @@ spec:
         {{- if .Values.persistence.export.enabled }}
         - name: export
           persistentVolumeClaim:
-            claimName: {{ include "paperless-ngx.fullname" . }}-export
+            claimName: {{ .Values.persistence.export.existingClaim | default (printf "%s-export" (include "paperless-ngx.fullname" .)) }}
         {{- else }}
         - name: export
           emptyDir: {}
@@ -348,7 +348,7 @@ spec:
         {{- if .Values.persistence.consume.enabled }}
         - name: consume
           persistentVolumeClaim:
-            claimName: {{ include "paperless-ngx.fullname" . }}-consume
+            claimName: {{ .Values.persistence.consume.existingClaim | default (printf "%s-consume" (include "paperless-ngx.fullname" .)) }}
         {{- else }}
         - name: consume
           emptyDir: {}

--- a/charts/paperless-ngx/templates/pvc.yaml
+++ b/charts/paperless-ngx/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.data.enabled }}
+{{- if and .Values.persistence.data.enabled (not .Values.persistence.data.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -21,7 +21,7 @@ spec:
 ---
 {{- end }}
 
-{{- if .Values.persistence.media.enabled }}
+{{- if and .Values.persistence.media.enabled (not .Values.persistence.media.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -44,7 +44,7 @@ spec:
 ---
 {{- end }}
 
-{{- if .Values.persistence.export.enabled }}
+{{- if and .Values.persistence.export.enabled (not .Values.persistence.export.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -67,7 +67,7 @@ spec:
 ---
 {{- end }}
 
-{{- if .Values.persistence.consume.enabled }}
+{{- if and .Values.persistence.consume.enabled (not .Values.persistence.consume.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/paperless-ngx/values.yaml
+++ b/charts/paperless-ngx/values.yaml
@@ -69,6 +69,7 @@ persistence:
     accessMode: ReadWriteOnce
     size: 1Gi
     annotations: {}
+    #existingClaim: ""
   # Paperless media directory (documents and thumbnails)
   media:
     enabled: true
@@ -76,6 +77,7 @@ persistence:
     accessMode: ReadWriteOnce
     size: 10Gi
     annotations: {}
+    #existingClaim: ""
   # Export directory (for exporting documents)
   export:
     enabled: true
@@ -83,6 +85,7 @@ persistence:
     accessMode: ReadWriteOnce
     size: 1Gi
     annotations: {}
+    #existingClaim: ""
   # Consume directory (for importing documents)
   consume:
     enabled: true
@@ -90,6 +93,7 @@ persistence:
     accessMode: ReadWriteOnce
     size: 5Gi
     annotations: {}
+    #existingClaim: ""
 
 # Extra volume mounts
 extraVolumeMounts: []


### PR DESCRIPTION
This PR adds the ability to use existing PersistentVolumeClaims for Paperless-ngx's data directories instead of creating new ones. This is necessary for other storage types and configurations where users want to reuse existing storage resources.

This allows users to reuse existing storage resources, which is useful for migrations, shared storage setups, or when using different storage classes/backends that require pre-provisioned PVCs.

**Changes:**
- Added existingClaim parameter to all persistence sections (data, media, consume, export) in values.yaml
- Updated the PVC templates to conditionally create PVCs only when existingClaim is not set
- Updated the README with documentation for the new parameters and a usage example in the production installation section
